### PR TITLE
Refine testimonial slider and add read‑more modal

### DIFF
--- a/assets/css/het-tstm.css
+++ b/assets/css/het-tstm.css
@@ -1,14 +1,15 @@
 :root{
     --het-green: #1e7f72;       /* ירוק כהה לכותרת */
     --het-text:  #111827;       /* שחור לגוף */
-    --het-gap:   24px;
+    /* מרווח ברירת מחדל בין קלפים */
+    --het-gap:   36px;
   }
   
   /* === GRID === */
   .het-tstm--grid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 24px;
+    gap: var(--het-gap);
     align-items: stretch;
   }
   @media (max-width: 1280px){ .het-tstm--grid { grid-template-columns: repeat(3, 1fr); } }
@@ -24,9 +25,11 @@
     background: #fff;
     border-radius: 16px;
     padding: 16px 18px;
+    border: 1px solid var(--het-green);
+    direction: rtl;
     box-shadow: 0 2px 10px rgba(0,0,0,.06);
     transition: box-shadow .18s ease, transform .18s ease;
-    text-align: right; /* RTL */
+    text-align: right;
   }
   .het-tstm-card:hover {
     transform: translateY(-3px);
@@ -46,8 +49,9 @@
     color: var(--het-green);
     font-weight: 700;
     line-height: 1.2;
+    text-align: right !important;
   }
-  .het-tstm-role { color: #6b7280; font-size: .95rem; margin-top: 2px; }
+  .het-tstm-role { color: #6b7280; font-size: .95rem; margin-top: 2px; text-align: right; }
   
   .het-tstm-stars { color: #f5a623; margin-top: 6px; font-size: 1rem; line-height: 1; }
   .het-tstm-stars .star { opacity: .35; }
@@ -62,8 +66,7 @@
     margin-inline-start: auto;     /* כפתור בצד ימין ב-RTL */
   }
 
-  .het-tstm .het-btn,
-  .het-tstm .het-tstm-more {
+  .het-tstm .het-btn {
     font-size: .95rem;
     background: var(--het-green) !important;
     color: #fff !important;
@@ -74,8 +77,7 @@
     transition: background .18s ease, color .18s ease;
   }
 
-  .het-tstm .het-btn:hover,
-  .het-tstm .het-tstm-more:hover {
+  .het-tstm .het-btn:hover {
     background: #fff !important;
     color: var(--het-green) !important;
   }
@@ -93,25 +95,37 @@
     background: #e6f4f2; color: #0f5e55; border: 1px solid #bfe5de;
   }
   
-  /* === SLIDER === */
-  .het-tstm--slider { --perView: 3; }
-  @media (max-width: 1024px){ .het-tstm--slider { --perView: 2; } }
-  @media (max-width: 768px){  .het-tstm--slider { --perView: 1; } }
-  
-  .het-tstm--slider .swiper { overflow: hidden; }
-  .het-tstm--slider .swiper-wrapper { align-items: stretch; }
-  .het-tstm--slider .swiper-slide {
-    height: auto; display: flex;
-    width: calc(100% / var(--perView));
-    overflow: visible;
-  }
-  .het-tstm--slider .swiper-slide.is-double {
-    width: calc(200% / var(--perView)); /* עדות ארוכה – רוחב כפול */
-  }
+/* === SLIDER === */
+/* אפשר תצוגת גבול בעת ריחוף מבלי לחתוך את הקלף */
+.het-tstm--slider .het-swiper {
+  overflow: visible;
+  padding-inline: var(--het-gap);
+}
+.het-tstm--slider .swiper-wrapper { align-items: stretch; }
+.het-tstm--slider .swiper-slide {
+  height: auto; display: flex;
+  overflow: visible;
+}
   .het-tstm--slider .het-tstm-card { height: 100%; }
-  
+
   /* ניווט */
   .het-tstm--slider .het-nav {
     margin-top: 16px; display: flex; gap: 24px; justify-content: center;
+  }
+
+  /* === LIGHTBOX === */
+  .het-tstm-modal {
+    position: fixed; inset: 0; z-index: 9999;
+    background: rgba(0,0,0,.6);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .het-tstm-modal-content {
+    background: #fff; max-width: 600px; max-height: 80vh; overflow: auto;
+    padding: 24px; border-radius: 16px; position: relative; text-align: right;
+    direction: rtl;
+  }
+  .het-tstm-modal-close {
+    position: absolute; top: 10px; inset-inline-end: 10px; cursor: pointer;
+    background: none; border: none; font-size: 1.5rem;
   }
   

--- a/assets/js/het-tstm.js
+++ b/assets/js/het-tstm.js
@@ -1,25 +1,40 @@
 (function($){
     function initSwiper(scope){
-      $(scope).find('.het-tstm--slider .het-swiper').each(function(){
-        var $wrap = $(this).closest('.het-tstm--slider');
-        var gap = parseInt(getComputedStyle($wrap[0]).getPropertyValue('--het-gap')) || 24;
-        new Swiper(this, {
-          slidesPerView: 'auto',     // רוחב נשלט ב-CSS (כולל is-double)
-          spaceBetween: gap,
-          slidesOffsetBefore: gap,
-          slidesOffsetAfter: gap,
-          slidesPerGroupAuto: true,  // לדלג נכון על כרטיס כפול
-          navigation: {
-            nextEl: $wrap.find('.het-next')[0],
-            prevEl: $wrap.find('.het-prev')[0],
-          }
+        $(scope).find('.het-tstm--slider .het-swiper').each(function(){
+          var $wrap = $(this).closest('.het-tstm--slider');
+          var gap = parseInt(getComputedStyle($wrap[0]).getPropertyValue('--het-gap')) || 24;
+          new Swiper(this, {
+            slidesPerView: 3,
+            slidesPerGroup: 1,
+            centeredSlides: true,
+            spaceBetween: gap,
+            navigation: {
+              nextEl: $wrap.find('.het-next')[0],
+              prevEl: $wrap.find('.het-prev')[0],
+            },
+            breakpoints: {
+              0: { slidesPerView: 1 },
+              768: { slidesPerView: 2 },
+              1024: { slidesPerView: 3 }
+            }
+          });
+        });
+      }
+
+      $(function(){
+        initSwiper(document);
+
+        $(document).on('click', '.het-tstm-more', function(){
+          var full = $(this).next('.het-tstm-full').html();
+          var $modal = $('<div class="het-tstm-modal"><div class="het-tstm-modal-content"><button class="het-tstm-modal-close" aria-label="Close">&times;</button>'+ full +'</div></div>');
+          $('body').append($modal);
+        });
+
+        $(document).on('click', '.het-tstm-modal-close, .het-tstm-modal', function(e){
+          if(e.target !== this && !$(e.target).hasClass('het-tstm-modal-close')) return;
+          $(this).closest('.het-tstm-modal').remove();
         });
       });
-    }
-
-    $(function(){
-      initSwiper(document);
-    });
 
     window.addEventListener('elementor/frontend/init', function(){
       elementorFrontend.hooks.addAction('frontend/element_ready/shortcode.default', function($scope){

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -58,14 +58,13 @@ class HET_TSTM_Shortcodes {
     ob_start();
     if ($q->have_posts()) {
       if ($a['layout'] === 'slider') {
-        echo '<div class="het-tstm het-tstm--slider">';
+        echo '<div class="het-tstm het-tstm--slider" dir="rtl">';
         echo '  <div class="het-swiper swiper"><div class="swiper-wrapper">';
         while ($q->have_posts()) { $q->the_post();
           include HET_TSTM_PATH.'templates/loop-item-slider.php';
         }
-        echo '  </div>';
+        echo '  </div></div>';
         echo '  <div class="het-nav"><button class="het-btn het-prev" aria-label="Previous">‹</button><button class="het-btn het-next" aria-label="Next">›</button></div>';
-        echo '  </div>';
         echo '</div>';
       } else {
         echo '<div class="het-tstm het-tstm--grid">';

--- a/templates/loop-item-slider.php
+++ b/templates/loop-item-slider.php
@@ -7,11 +7,13 @@ $company = het_tstm_get_meta($id,'het_tstm_company');
 $rating  = (int)het_tstm_get_meta($id,'het_tstm_rating', 0);
 
 $content = get_the_content();
-$is_long = mb_strlen( wp_strip_all_tags( $content ) ) > 350; // סף “ארוך”
+$content_html = wp_kses_post( $content );
+$is_long = mb_strlen( wp_strip_all_tags( $content_html ) ) > 350; // סף “ארוך”
+$preview = $is_long ? esc_html( wp_trim_words( wp_strip_all_tags( $content_html ), 40, '...' ) ) : $content_html;
 
 ?>
-<div class="swiper-slide<?php echo $is_long ? ' is-double' : ''; ?>">
-  <article class="het-tstm-item het-tstm-card">
+<div class="swiper-slide">
+  <article class="het-tstm-item het-tstm-card" dir="rtl">
     <div class="het-tstm-top">
       <div class="het-tstm-avatar"><?php if (has_post_thumbnail()) the_post_thumbnail('thumbnail'); ?></div>
       <div class="het-tstm-meta">
@@ -28,6 +30,12 @@ $is_long = mb_strlen( wp_strip_all_tags( $content ) ) > 350; // סף “ארוך
         <?php endif; ?>
       </div>
     </div>
-    <div class="het-tstm-body"><?php echo wpautop( wp_kses_post($content) ); ?></div>
+    <div class="het-tstm-body"><?php echo wpautop( $preview ); ?></div>
+    <?php if ($is_long): ?>
+      <button type="button" class="het-btn het-tstm-more"><?php echo esc_html__('קראי עוד...', 'het'); ?></button>
+      <div class="het-tstm-full" style="display:none;">
+        <?php echo wpautop( $content_html ); ?>
+      </div>
+    <?php endif; ?>
   </article>
 </div>


### PR DESCRIPTION
## Summary
- style testimonial cards with green borders and RTL alignment
- remove double-width logic and add a read-more button that opens full text in a lightbox
- expose slider navigation arrows for advancing through testimonials

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68b41ad36650832faf3b75ee91dfd4d9