### PR TITLE
Add front-end testimonial submission popup

### DIFF
--- a/assets/js/het-tstm.js
+++ b/assets/js/het-tstm.js
@@ -36,6 +36,36 @@
           if(e.target !== this && !$(e.target).hasClass('het-tstm-modal-close')) return;
           $(this).closest('.het-tstm-modal').remove();
         });
+
+        $(document).on('click', '.het-add-testimony', function(){
+          var html = $(this).next('.het-add-form').html();
+          var $modal = $('<div class="het-tstm-modal"><div class="het-tstm-modal-content"><button type="button" class="het-btn het-tstm-modal-close" aria-label="Close">&times;</button>'+ html +'</div></div>');
+          $('body').append($modal);
+        });
+
+        $(document).on('submit', '.het-tstm-form', function(e){
+          e.preventDefault();
+          var $form = $(this);
+          var fd = new FormData(this);
+          $.ajax({
+            url: typeof hetTstm !== 'undefined' ? hetTstm.ajax_url : '',
+            type: 'POST',
+            data: fd,
+            processData: false,
+            contentType: false
+          }).done(function(res){
+            if(res.data && res.data.message){
+              $form.find('.het-tstm-msg').text(res.data.message);
+            }
+            $form[0].reset();
+          }).fail(function(xhr){
+            var msg = 'Error';
+            if(xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message){
+              msg = xhr.responseJSON.data.message;
+            }
+            $form.find('.het-tstm-msg').text(msg);
+          });
+        });
       });
 
     window.addEventListener('elementor/frontend/init', function(){

--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -18,6 +18,9 @@ class HET_TSTM_Assets {
     // JS התוסף
     wp_register_script('het-tstm', HET_TSTM_URL.'assets/js/het-tstm.js', ['jquery'], HET_TSTM_VER, true);
     wp_enqueue_script('het-tstm');
+    wp_localize_script('het-tstm', 'hetTstm', [
+      'ajax_url' => admin_url('admin-ajax.php'),
+    ]);
 
     // Swiper (רק אם נמצא מרקר בדף — חסכוני, אבל בטוח לטעון תמיד אם רוצים)
     if ( ! wp_script_is('swiper', 'registered') ) {

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -8,8 +8,15 @@ class HET_TSTM_Shortcodes {
   }
 
   public function render_form($atts = []) {
+    $a = shortcode_atts([
+      'simple' => '0',
+    ], $atts, 'het_testimony_form');
     ob_start();
-    include HET_TSTM_PATH.'templates/form.php';
+    if ($a['simple'] === '1') {
+      include HET_TSTM_PATH.'templates/form-simple.php';
+    } else {
+      include HET_TSTM_PATH.'templates/form.php';
+    }
     return ob_get_clean();
   }
 
@@ -65,6 +72,9 @@ class HET_TSTM_Shortcodes {
         }
         echo '  </div></div>';
         echo '  <div class="het-nav"><button class="het-btn het-prev" aria-label="Previous">‹</button><button class="het-btn het-next" aria-label="Next">›</button></div>';
+        $form_html = $this->render_form(['simple' => '1']);
+        echo '  <button class="het-btn het-add-testimony">'.esc_html__('השאירי תגובה','het').'</button>';
+        echo '  <div class="het-add-form" style="display:none;">'.$form_html.'</div>';
         echo '</div>';
       } else {
         echo '<div class="het-tstm het-tstm--grid">';

--- a/templates/form-simple.php
+++ b/templates/form-simple.php
@@ -1,0 +1,18 @@
+<?php
+// Simple testimonial form
+?>
+<form id="het-tstm-form" class="het-tstm-form">
+  <input type="hidden" name="action" value="het_submit_testimony">
+  <input type="hidden" name="nonce" value="<?php echo esc_attr( wp_create_nonce('het_tstm_nonce') ); ?>">
+  <input type="text" name="website" value="" class="hp" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px;">
+  <div class="row">
+    <label>שם מלא *</label>
+    <input type="text" name="name" required>
+  </div>
+  <div class="row">
+    <label>המלצה *</label>
+    <textarea name="content" rows="5" required></textarea>
+  </div>
+  <button type="submit" class="btn">שלחי</button>
+  <div class="het-tstm-msg" aria-live="polite"></div>
+</form>


### PR DESCRIPTION
## Summary
- add "השאירי תגובה" button under testimonial slider navigation
- display minimal "add testimony" form in popup and submit via AJAX
- expose admin-ajax URL to scripts for form submission

## Testing
- `php -l includes/class-shortcodes.php`
- `php -l includes/class-assets.php`
- `php -l templates/form-simple.php`
- `node --check assets/js/het-tstm.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4756fa2a0832fbbb0e44b14002e51